### PR TITLE
un-hide the Media tab for organizations

### DIFF
--- a/app/views/admin/organizations/_sidebar.html.erb
+++ b/app/views/admin/organizations/_sidebar.html.erb
@@ -15,14 +15,12 @@
     <div class="bottom_selected">
       <%= link_to('Organization projects', admin_organization_projects_path(@organization)) %><% if @organization.projects.present? %> <p><span><%=@organization.projects.count%></span></p><% end %>
     </div>
-    </li>
-  <% if false -%>
+  </li>
   <li <%= selected_if_current_page(admin_organization_media_resources_path(@organization)) %>>
     <div class="bottom_selected">
     <%= link_to("Media", admin_organization_media_resources_path(@organization)) %><% if !@organization.media_resources.empty? %> <p><span><%=@organization.media_resources.count%></span></p><% end %>
     </div>
   </li>
-  <% end -%>
   <li <%= selected_if_current_page(admin_organization_resources_path(@organization)) %>>
         <div class="bottom_selected">
           <%= link_to("Resources", admin_organization_resources_path(@organization)) %><% if !@organization.resources.empty? %> <p><span><%=@organization.resources.count%></span></p><% end %>


### PR DESCRIPTION
Un-hide the Media tab for organizations.

#13 

I thought I'd have to add to the org form, but it references the same media form as Projects that I already edited.  So, letting that work occur in the Projects feature branch.