### PR TITLE
Remove org project count from org dropdown

### DIFF
--- a/app/views/admin/projects/_form.html.erb
+++ b/app/views/admin/projects/_form.html.erb
@@ -22,7 +22,7 @@
       <div class="wrapper">
         <ul class="organization_combo_content list_combo_content huge_list_combo_content scroll_pane">
             <% @organizations_list.each do |organization| %>
-              <li class="element" id="orgs_<%= organization.id %>"><p class="project_name"><%= truncate(organization.name, :length=> 60) %></p><p class="amount_projects"><%= pluralize(organization.projects.count, 'project', 'projects')%></p></li>
+              <li class="element" id="orgs_<%= organization.id %>"><p class="project_name"><%= truncate(organization.name, :length=> 60) %></p></li>
             <% end -%>
         </ul>
       </div>

--- a/public/app/stylesheets/backoffice/layout.css
+++ b/public/app/stylesheets/backoffice/layout.css
@@ -2043,11 +2043,8 @@ div.block.edit div.med div.left form ul.list_combo3_content {
       color: #333333;
       width: auto; }
     div.block.edit div.med div.left form ul.list_combo,
-    div.block.edit div.med div.left form ul.list_combo_content li.element p.amount_projects,
     div.block.edit div.med div.left form ul.list_combo2,
-    div.block.edit div.med div.left form ul.list_combo2_content li.element p.amount_projects,
-    div.block.edit div.med div.left form ul.list_combo3,
-    div.block.edit div.med div.left form ul.list_combo3_content li.element p.amount_projects {
+    div.block.edit div.med div.left form ul.list_combo3, {
       position: absolute;
       top: 7px;
       right: 10px;
@@ -3028,15 +3025,6 @@ div.block.project_info div.med div.left form ul.huge_list_combo_content {
       width: 415px;
       white-space: nowrap;
     }
-    div.block.project_info div.med div.left form ul.list_combo_content li.element p.amount_projects,
-    div.block.project_info div.med div.left form ul.list_combo2_content li.element p.amount_projects,
-    div.block.project_info div.med div.left form ul.list_combo3_content li.element p.amount_projects {
-      position: absolute;
-      top: 7px;
-      right: 30px;
-      font: normal 13px Arial;
-      color: #666666;
-      width: auto; }
     div.block.project_info div.med div.left form ul.list_combo_content li.element:hover,
     div.block.project_info div.med div.left form ul.list_combo2_content li.element:hover,
     div.block.project_info div.med div.left form ul.list_combo3_content li.element:hover {


### PR DESCRIPTION
project counts by organization in the top organization dropdown of the project form (super admin only) have been the primary culprit in slowing down the loading of these pages (40s+ load!!). 

As this feature is unnecessary and not really used, for expediency, I removed it.  Now loading @ only 4s.